### PR TITLE
fix: installCRDs is deprecated

### DIFF
--- a/common/cert-manager/main.tf
+++ b/common/cert-manager/main.tf
@@ -17,7 +17,9 @@ locals {
           namespace = var.k8s_namespace
         }
       }
-      installCRDs = true
+      crds = {
+        enabled = true
+      }
     })
   ]
 }


### PR DESCRIPTION
This is a warning I got when deploying this helm chart through the `platform` tf module.