### PR TITLE
fix: add a label to startupapi pod

### DIFF
--- a/common/cert-manager/main.tf
+++ b/common/cert-manager/main.tf
@@ -20,6 +20,11 @@ locals {
       crds = {
         enabled = true
       }
+      startupapicheck = {
+        podAnnotations = {
+          "sidecar.istio.io/inject" = "false"
+        }
+      }
     })
   ]
 }


### PR DESCRIPTION
Copied this block from upstream at https://github.com/thoughtbot/flightdeck/blob/main/platform/modules/cert-manager/main.tf
